### PR TITLE
Add SwiftUI demo app

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,22 @@
 
 import PackageDescription
 
+#if canImport(SwiftUI)
+let demoProducts: [Product] = [
+    .executable(
+        name: "RickMortyDemoApp",
+        targets: ["RickMortyDemoApp"])
+]
+let demoTargets: [Target] = [
+    .executableTarget(
+        name: "RickMortyDemoApp",
+        dependencies: ["RickMortySwiftApi"])
+]
+#else
+let demoProducts: [Product] = []
+let demoTargets: [Target] = []
+#endif
+
 let package = Package(
     name: "RickMortySwiftApi",
     platforms: [
@@ -14,7 +30,7 @@ let package = Package(
         .library(
             name: "RickMortySwiftApi",
             targets: ["RickMortySwiftApi"]),
-    ],
+    ] + demoProducts,
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
@@ -25,6 +41,7 @@ let package = Package(
         .target(
             name: "RickMortySwiftApi",
             dependencies: []),
+    ] + demoTargets + [
         .testTarget(
             name: "RickMortySwiftApiTests",
             dependencies: ["RickMortySwiftApi"]),

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ do {
 
 *For more examples, please refer to the [Documentation][doc-link] or visit [Test Section][test-link]*
 
+## Demo App
+
+The repository contains a small SwiftUI demo that uses this package to fetch data and present it in a tab bar with characters, episodes and locations.
+Run it via the executable target `RickMortyDemoApp`:
+
+```bash
+swift run RickMortyDemoApp
+```
+
 
 <!-- CONTRIBUTING -->
 ## Contributing

--- a/Sources/RickMortyDemoApp/CharactersView.swift
+++ b/Sources/RickMortyDemoApp/CharactersView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import RickMortySwiftApi
+
+struct CharactersView: View {
+    @State private var characters: [RMCharacterModel] = []
+    @State private var isLoading = true
+    private let client = RMClient()
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if isLoading {
+                    ProgressView()
+                } else {
+                    List(characters) { character in
+                        CharacterCard(character: character)
+                            .listRowSeparator(.hidden)
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle("Characters")
+        }
+        .task {
+            await loadCharacters()
+        }
+    }
+
+    @MainActor
+    private func loadCharacters() async {
+        do {
+            characters = try await client.character().getAllCharacters()
+        } catch {
+            print("Error fetching characters: \(error)")
+        }
+        isLoading = false
+    }
+}
+
+struct CharacterCard: View {
+    let character: RMCharacterModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                AsyncImage(url: URL(string: character.image)) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 80, height: 80)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    case .failure:
+                        Image(systemName: "photo")
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+                VStack(alignment: .leading) {
+                    Text(character.name)
+                        .font(.headline)
+                    Text(character.species)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color(.systemBackground)).shadow(radius: 2))
+    }
+}
+
+#Preview {
+    CharactersView()
+}

--- a/Sources/RickMortyDemoApp/ContentView.swift
+++ b/Sources/RickMortyDemoApp/ContentView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            CharactersView()
+                .tabItem {
+                    Label("Characters", systemImage: "person.3.fill")
+                }
+            EpisodesView()
+                .tabItem {
+                    Label("Episodes", systemImage: "tv.fill")
+                }
+            LocationsView()
+                .tabItem {
+                    Label("Locations", systemImage: "map.fill")
+                }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Sources/RickMortyDemoApp/EpisodesView.swift
+++ b/Sources/RickMortyDemoApp/EpisodesView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import RickMortySwiftApi
+
+struct EpisodesView: View {
+    @State private var episodes: [RMEpisodeModel] = []
+    @State private var isLoading = true
+    private let client = RMClient()
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if isLoading {
+                    ProgressView()
+                } else {
+                    List(episodes) { episode in
+                        EpisodeCard(episode: episode)
+                            .listRowSeparator(.hidden)
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle("Episodes")
+        }
+        .task {
+            await loadEpisodes()
+        }
+    }
+
+    @MainActor
+    private func loadEpisodes() async {
+        do {
+            episodes = try await client.episode().getAllEpisodes()
+        } catch {
+            print("Error fetching episodes: \(error)")
+        }
+        isLoading = false
+    }
+}
+
+struct EpisodeCard: View {
+    let episode: RMEpisodeModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(episode.name)
+                .font(.headline)
+            Text(episode.episode)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text(episode.airDate)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color(.systemBackground)).shadow(radius: 2))
+    }
+}
+
+#Preview {
+    EpisodesView()
+}

--- a/Sources/RickMortyDemoApp/LocationsView.swift
+++ b/Sources/RickMortyDemoApp/LocationsView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import RickMortySwiftApi
+
+struct LocationsView: View {
+    @State private var locations: [RMLocationModel] = []
+    @State private var isLoading = true
+    private let client = RMClient()
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if isLoading {
+                    ProgressView()
+                } else {
+                    List(locations) { location in
+                        LocationCard(location: location)
+                            .listRowSeparator(.hidden)
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle("Locations")
+        }
+        .task {
+            await loadLocations()
+        }
+    }
+
+    @MainActor
+    private func loadLocations() async {
+        do {
+            locations = try await client.location().getAllLocations()
+        } catch {
+            print("Error fetching locations: \(error)")
+        }
+        isLoading = false
+    }
+}
+
+struct LocationCard: View {
+    let location: RMLocationModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(location.name)
+                .font(.headline)
+            Text(location.type)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text(location.dimension)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color(.systemBackground)).shadow(radius: 2))
+    }
+}
+
+#Preview {
+    LocationsView()
+}

--- a/Sources/RickMortyDemoApp/RickMortyDemoApp.swift
+++ b/Sources/RickMortyDemoApp/RickMortyDemoApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+import RickMortySwiftApi
+
+@main
+struct RickMortyDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add iOS/macOS SwiftUI demo app with characters, episodes and locations tabs
- document how to run the demo app in README
- include demo app target conditionally in Package.swift
- ensure data-loading functions update UI state on the main actor

## Testing
- `swift build`
- `swift test` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca5909048325b106693d6bef81d9